### PR TITLE
agentic retry loop with attempt context + eval bug fixes (#20)

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -4,6 +4,7 @@
 Usage:
     python bench.py
 """
+import getpass
 import os
 import subprocess
 import sys
@@ -91,7 +92,7 @@ def main() -> None:
     if key_var:
         api_key = os.environ.get(key_var, "").strip() or None
         if not api_key:
-            api_key = input(f"\n  {key_var}: ").strip() or None
+            api_key = getpass.getpass(f"\n  {key_var}: ").strip() or None
         if not api_key:
             sys.exit(f"\nError: {key_var} is required for {provider}.")
 

--- a/fixtures/starter_v3/ambiguous.json
+++ b/fixtures/starter_v3/ambiguous.json
@@ -95,12 +95,12 @@
       ],
       "initial_scene": {"mode": "OBJECT", "objects": []},
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+        "mesh_object_count": {"minimum": 2}
       },
       "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
       "soft_constraints": [
         {"name": "house has multiple parts", "metric": "total_mesh_objects", "direction": "min",
-         "target": 1.0, "tolerance": 0.0, "weight": 0.5}
+         "target": 2.0, "tolerance": 0.0, "weight": 0.5}
       ],
       "style_intent": {
         "explicit": false,

--- a/nalana_eval/contracts.py
+++ b/nalana_eval/contracts.py
@@ -436,9 +436,11 @@ def normalize_model_output(raw_output: Any) -> Tuple[List[NormalizedStep], Outpu
     """
     parsed = _parse_json_payload(raw_output)
 
-    # Unwrap {"commands": [...]} wrapper
-    if isinstance(parsed, dict) and "commands" in parsed:
-        parsed = parsed["commands"]
+    # Unwrap any single-key dict wrapping a list (handles "commands", "steps", "operations", etc.)
+    if isinstance(parsed, dict):
+        list_vals = [(k, v) for k, v in parsed.items() if isinstance(v, list)]
+        if len(list_vals) == 1:
+            parsed = list_vals[0][1]
 
     if isinstance(parsed, dict):
         parsed = [parsed]

--- a/nalana_eval/harness.py
+++ b/nalana_eval/harness.py
@@ -340,6 +340,7 @@ class Harness:
         attempt_index: int,
         output_dir: Path,
         is_honeypot: bool = False,
+        previous_attempts: Optional[List[AttemptArtifact]] = None,
     ) -> AttemptArtifact:
         screenshots_dir = output_dir / "screenshots"
         screenshots_dir.mkdir(parents=True, exist_ok=True)
@@ -347,7 +348,7 @@ class Harness:
         prompt_used = _select_prompt(case, attempt_index, self._rng)
 
         # Step 1: call model
-        invocation = runner.generate(prompt_used, case, attempt_index)
+        invocation = runner.generate(prompt_used, case, attempt_index, previous_attempts)
 
         artifact = AttemptArtifact(
             case_id=case.id,
@@ -470,8 +471,13 @@ class Harness:
                 )
                 all_attempts.append(hp_attempt)
 
+            case_attempts: List[AttemptArtifact] = []
             for attempt_idx in range(self.config.pass_at_k):
-                attempt = self._run_single_attempt(runner, case, attempt_idx, output_dir)
+                attempt = self._run_single_attempt(
+                    runner, case, attempt_idx, output_dir,
+                    previous_attempts=case_attempts or None,
+                )
+                case_attempts.append(attempt)
                 all_attempts.append(attempt)
 
                 if attempt.pass_overall:

--- a/nalana_eval/runners/base.py
+++ b/nalana_eval/runners/base.py
@@ -5,10 +5,11 @@ import json
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from nalana_eval.contracts import normalize_model_output
 from nalana_eval.schema import (
+    AttemptArtifact,
     FailureClass,
     ModelInvocation,
     OutputContract,
@@ -16,6 +17,47 @@ from nalana_eval.schema import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _build_retry_context(previous_attempts: List[AttemptArtifact]) -> str:
+    lines = [
+        "\n\n---\nPrevious attempt(s) failed. Use this context to improve your response:",
+        "IMPORTANT: The scene is fully reset to its initial state before each attempt.",
+        "Your response must include ALL operations needed to complete the task from scratch — do not assume anything from previous attempts carries over.",
+    ]
+    for prev in previous_attempts:
+        lines.append(f"\nAttempt {prev.attempt_index + 1}:")
+        lines.append(f"  Failure: {prev.failure_class.value} — {prev.failure_reason or 'unknown reason'}")
+
+        if prev.normalized_output:
+            step_strs = [
+                f"{s.kind.value}({', '.join(f'{k}={v}' for k, v in s.args.items())})"
+                for s in prev.normalized_output
+            ]
+            lines.append(f"  Commands executed: {', '.join(step_strs)}")
+        elif prev.raw_output is not None:
+            raw_str = (
+                prev.raw_output if isinstance(prev.raw_output, str)
+                else json.dumps(prev.raw_output)
+            )
+            lines.append(f"  Your output (truncated): {raw_str[:400]}")
+
+        snap = prev.scene_snapshot
+        if snap.mesh_objects:
+            obj_strs = [
+                f"{m.name}(verts={m.vertex_count}, faces={m.face_count}, "
+                f"location=[{', '.join(f'{x:.2f}' for x in m.location)}])"
+                for m in snap.mesh_objects
+            ]
+            lines.append(
+                f"  Scene after execution: {snap.total_mesh_objects} mesh object(s) — "
+                + ", ".join(obj_strs)
+            )
+        elif prev.execution_success:
+            lines.append("  Scene after execution: 0 mesh objects")
+
+    lines.append("\nPlease fix the issues described above.\n---")
+    return "\n".join(lines)
 
 
 class BaseModelRunner(ABC):
@@ -49,6 +91,7 @@ class BaseModelRunner(ABC):
         prompt: str,
         case: TestCaseCard,
         attempt_index: int,
+        previous_attempts: Optional[List[AttemptArtifact]] = None,
     ) -> ModelInvocation:
         """Call the model and normalize output. Never raises — failures recorded in result."""
         invocation = ModelInvocation(
@@ -56,9 +99,13 @@ class BaseModelRunner(ABC):
             prompt=prompt,
         )
 
+        effective_prompt = prompt
+        if previous_attempts:
+            effective_prompt = prompt + _build_retry_context(previous_attempts)
+
         started = time.perf_counter()
         try:
-            raw_str = self._generate(prompt, self.temperature, self.seed + attempt_index)
+            raw_str = self._generate(effective_prompt, self.temperature, self.seed + attempt_index)
         except Exception as exc:
             invocation.model_latency_ms = (time.perf_counter() - started) * 1000.0
             invocation.parse_error = f"API error: {exc}"

--- a/nalana_eval/runners/openai_runner.py
+++ b/nalana_eval/runners/openai_runner.py
@@ -84,12 +84,18 @@ class OpenAIRunner(BaseModelRunner):
             messages.append({"role": "system", "content": self.system_prompt})
         messages.append({"role": "user", "content": prompt})
 
-        resp = client.chat.completions.create(
-            model=deployment,
-            messages=messages,
-            response_format={"type": "json_object"},
+        create_kwargs: Dict[str, Any] = {
+            "model": deployment,
+            "messages": messages,
             **_build_params(deployment, temperature, seed, self.max_tokens),
-        )
+        }
+        # json_object forces dict output, which contradicts the system prompt's
+        # instruction to return a JSON array. Only use it for models that need
+        # it to avoid prose (gpt-4o etc.). Restricted models (gpt-5.x, o-series)
+        # follow JSON instructions reliably without enforcement.
+        if not _is_restricted(self.model_id):
+            create_kwargs["response_format"] = {"type": "json_object"}
+        resp = client.chat.completions.create(**create_kwargs)
         if resp.usage:
             self._last_input_tokens  = resp.usage.prompt_tokens
             self._last_output_tokens = resp.usage.completion_tokens

--- a/prompts/eval_default.md
+++ b/prompts/eval_default.md
@@ -47,11 +47,23 @@ VALID PRIMITIVES
 - CUBE, UV_SPHERE, ICO_SPHERE, CYLINDER, CONE, TORUS
 
 VALID STEP KINDS (for NORMALIZED contract)
-- ADD_MESH, SET_MODE, TRANSLATE, SCALE, ROTATE, BEVEL, INSET, EXTRUDE_REGION, SET_CAMERA, SET_MATERIAL
+- ADD_MESH(primitive, size/radius/depth/vertices, location:[x,y,z], rotation:[x,y,z], scale:[x,y,z])
+- SET_MODE(mode: OBJECT|EDIT)
+- TRANSLATE(value:[x,y,z])
+- SCALE(value:[x,y,z])
+- ROTATE(value:radians_scalar, orient_axis:X|Y|Z)  — value is a single float, NOT a vector
+- BEVEL(offset, segments, profile)
+- INSET(thickness, depth)
+- EXTRUDE_REGION(translate:[x,y,z])
+- SET_CAMERA(name)
+- SET_MATERIAL(name, base_color:[r,g,b])
+- DELETE_ALL()  — removes all objects from the scene
+- SELECT_ALL(action: SELECT|DESELECT|TOGGLE|INVERT)
 
 EXAMPLE OUTPUT (NORMALIZED contract):
 [
-  {"kind": "ADD_MESH", "args": {"primitive": "CUBE", "size": 2.0, "location": [0, 0, 0]}}
+  {"kind": "ADD_MESH", "args": {"primitive": "CUBE", "size": 2.0, "location": [0, 0, 0]}},
+  {"kind": "ROTATE", "args": {"value": 0.785, "orient_axis": "Z"}}
 ]
 
 EXAMPLE OUTPUT (LEGACY_OPS contract):
@@ -85,6 +97,7 @@ EXAMPLE OUTPUT (LEGACY_OPS contract):
 | 版本 | 日期 | 变化 | 校准集影响 |
 |---|---|---|---|
 | v1 | 2026-04-25 | 初版 | baseline established |
+| v2 | 2026-04-29 | 补充 DELETE_ALL/SELECT_ALL；为所有 step kinds 加参数文档；修正 ROTATE 格式说明（scalar+axis，非 euler vector）；NORMALIZED 示例加 ROTATE | **需要重跑 baseline** |
 
 ---
 


### PR DESCRIPTION
 # Agentic retry loop
  - Each failed attempt now passes its failure reason, executed commands, and post-execution scene snapshot to the next attempt for the same test case
  - Models are explicitly told the scene resets between attempts so they don't try to build incrementally across retries

 # Eval bug fixes
  - Added DELETE_ALL and SELECT_ALL to the system prompt's valid step kinds (were missing, causing models to hallucinate command names or skip delete tasks entirely)
  - Documented argument types for all step kinds in the system prompt; fixed ROTATE format (value is a scalar + axis, not an euler vector)
  - Expanded output contract parser to unwrap any single-key list wrapper (e.g. {"steps": [...]}, {"operations": [...]}) not just {"commands": [...]}
  - Removed response_format: json_object for gpt-5.x/o-series models — it forced dict output, directly contradicting the system prompt's instruction to return a JSON array