### PR TITLE
feat(schema): add SceneComplexity, Provenance, Tag, draft fields (ADR-005 — #15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ For details on any entry, follow the linked PR / handoff doc / ADR.
 
 ---
 
+## 2026-05-02 — #13.1: schema fields (SceneComplexity / Provenance / Tag / draft) + mechanical fixture backfill
+
+Per ADR-005, schema-level taxonomy lands. Pure infrastructure PR — no judgment-based data changes (those land in #13.2 audit).
+
+Schema changes (`nalana_eval/schema.py`):
+- New enums: `SceneComplexity` (single_object / multi_object / composition / full_scene), `Provenance` (handcrafted / synthetic / llm_authored), `Tag` (canonical / adversarial / ambiguous / honeypot)
+- New required field on `TestCaseCard`: `scene_complexity: SceneComplexity = SINGLE_OBJECT` (default = safe placeholder; #13.2 corrects ~10-15 cases)
+- New optional fields: `provenance: Provenance = HANDCRAFTED`, `draft: bool = False`, `tags: List[Tag] = []`
+- Existing field `difficulty: Difficulty` made `Optional` (deprecated per ADR-005, removal in v3.2)
+
+Existing 80 fixtures backfilled mechanically:
+- All cases get `scene_complexity: "single_object"` (placeholder — #13.2 audit corrects the ~10-15 that should be multi_object/composition/full_scene)
+- `starter_v3/*` cases get `provenance: "handcrafted"`; `synthetic/*` get `provenance: "synthetic"`
+- All cases get `tags: ["canonical"]`
+
+Tests (`tests/test_schema.py`):
+- 14 new tests covering each new enum value, defaults, validation, deprecation back-compat
+- All existing tests pass unchanged
+
+Side cleanup:
+- `docs/handoffs/2026-04-29-post-merge-cleanup.md` status flipped `in_progress` → `shipped` (PR-A merged 2026-04-30; this update was one of #21's bundled follow-ups)
+
+Refs: ADR-005, #13.0 (covered by ADR-005 PR), #13.1 GitHub issue, [docs/handoffs/2026-05-02-13.1-schema-fields.md](docs/handoffs/2026-05-02-13.1-schema-fields.md). Blocks #13.2 (existing-fixture audit) and #13.3 (LLM authoring CLI).
+
+---
+
 ## 2026-04-30 — ADR-005: TaskLength dropped, SceneComplexity added, L3 judge for spatial coherence
 
 Doc-only PR. Taxonomy redesign of `TestCaseCard` axes feeding #13 (Test case authoring pipeline). Five linked decisions made via chat 2026-04-30:

--- a/docs/handoffs/2026-04-29-post-merge-cleanup.md
+++ b/docs/handoffs/2026-04-29-post-merge-cleanup.md
@@ -1,12 +1,12 @@
 # Handoff: PR-A — post-merge cleanup + handover infrastructure
 
 ```yaml
-status:        in_progress
+status:        shipped
 owner:         ian + Claude Cowork
 related_task:  #18, #19
 related_pr:    (TBD on push)
 date_opened:   2026-04-29
-date_closed:   —
+date_closed:   2026-04-30
 ```
 
 ---

--- a/docs/handoffs/2026-05-02-13.1-schema-fields.md
+++ b/docs/handoffs/2026-05-02-13.1-schema-fields.md
@@ -1,0 +1,103 @@
+# Handoff: #13.1 — Schema fields (SceneComplexity / Provenance / Tag / draft) + fixture backfill
+
+```yaml
+status:        in_progress
+owner:         ian + Claude Cowork
+related_task:  #13.1 (GitHub #26)
+related_pr:    (TBD on push)
+date_opened:   2026-05-02
+date_closed:   —
+```
+
+---
+
+## 1. What this is
+
+ADR-005 lands its schema-level decisions as code. Pure infrastructure PR: three new enums (`SceneComplexity`, `Provenance`, `Tag`) + four new fields on `TestCaseCard` (`scene_complexity`, `provenance`, `draft`, `tags`) + the existing `difficulty` field becomes `Optional` (deprecated, removal in v3.2). Existing 80 fixtures get backfilled with safe defaults so the schema change is non-breaking.
+
+Per Q4-A in the design discussion, the audit pass that **corrects** wrong default values for `scene_complexity` (and flips `judge_policy=score` + expands `acceptable_styles` for COMPOSITION/FULL_SCENE cases) is **deferred to #13.2** as a separate PR. This keeps #13.1 reviewable as pure mechanical infrastructure.
+
+## 2. Why now — what triggered this
+
+ADR-005 (merged 2026-04-30) defines the taxonomy. #13.1 is the first implementation step. Without these schema fields, downstream issues are blocked:
+
+- #13.2 fixture audit needs `scene_complexity` slot to write into
+- #13.3 LLM authoring CLI needs `provenance="llm_authored"` + `draft=True` to mark its output
+- #13.4 drift checker needs `tags` + `scene_complexity` to validate cross-consistency
+- #13.5 honeypot infrastructure needs `Tag.HONEYPOT`
+
+This is the unblock-everything-else PR.
+
+## 3. Scope
+
+```
+In:
+- nalana_eval/schema.py  — three new enums + four new fields on TestCaseCard;
+                           Difficulty field becomes Optional (deprecated)
+- 7 fixture files / 80 cases backfilled mechanically:
+    fixtures/starter_v3/{ambiguous,compositional,materials,object_creation,
+                         safety,transformations}.json
+    fixtures/synthetic/generated_primitive_cases.json
+- tests/test_schema.py   — 14 new tests
+- docs/handoffs/2026-04-29-post-merge-cleanup.md  — status: in_progress → shipped
+                                                     (PR-A merged; this is one of
+                                                     #21's bundled follow-ups)
+- CHANGELOG.md           — one entry block
+- docs/handoffs/2026-05-02-13.1-schema-fields.md  — this file
+
+Out (deferred to follow-up PRs):
+- Existing-fixture audit (correct scene_complexity, flip judge_policy,
+  expand acceptable_styles)                       → #13.2
+- LLM authoring CLI                               → #13.3
+- Drift checker                                   → #13.4
+- Honeypot infrastructure                         → #13.5
+- USAGE_GUIDE cost-projection update              → bundled with #13.2
+- CLI deprecation warning on --difficulty-dist    → bundled with #13.2
+```
+
+## 4. Decisions made
+
+Resolved in chat 2026-05-02 (4 sub-decisions to ADR-005):
+
+```
+Q1. Provenance enum location: same module-level position in schema.py
+    as SceneComplexity. No new file.
+Q2. Provenance backfill: by-directory (starter_v3/* = handcrafted;
+    synthetic/* = synthetic). Mechanical, 30 sec via Python script.
+Q3. tags backfill: ["canonical"] for all 80 existing cases. Future LLM
+    batches will not carry canonical tag, providing a natural baseline-vs-new
+    distinction for reporting.
+Q4. PR split: #13.1 mechanical (schema + safe-default backfill) is separate
+    from #13.2 judgmental (audit corrects wrong defaults + flips judge_policy).
+    Both files in #13.1 are mechanically derivable; #13.2 requires per-case
+    judgment. Splits clean review boundaries.
+```
+
+## 5. How to verify
+
+- [ ] `pytest tests/test_schema.py -v` — all green (existing tests + 14 new)
+- [ ] All 80 fixtures load: `python -c "from nalana_eval.schema import TestSuite; TestSuite.from_json_or_dir('fixtures/starter_v3'); TestSuite.from_json_or_dir('fixtures/synthetic')"` (or whatever the loader entry point is)
+- [ ] `git diff --stat HEAD~1` shows: `schema.py` + 7 fixture JSONs + `test_schema.py` + handoff/CHANGELOG only
+- [ ] No CSV column changes (case fields don't propagate to attempts.csv; verified by `grep -c "scene_complexity\|provenance\|tags" nalana_eval/csv_db.py` returning 0)
+- [ ] Spot-check one fixture per directory has the three new fields:
+    ```
+    grep -l '"scene_complexity"' fixtures/starter_v3/*.json
+    # Should list all 6 files
+    ```
+
+## 6. Known issues / TODOs / handoff to next
+
+- **#13.2 PR is the immediate next step**. It corrects the placeholder `scene_complexity: "single_object"` on the ~10-15 cases that should be MULTI_OBJECT / COMPOSITION / FULL_SCENE, and flips `judge_policy=score` + expands `acceptable_styles` for those.
+- **`difficulty` field stays in 80 fixtures** during deprecation cycle. Removal of the field from fixtures and schema both happen in v3.2 (target ~6-8 weeks after #13 ships).
+- **No CLI deprecation warning yet** on `--difficulty-dist` — bundled with #13.2 to avoid noisy intermediate state.
+- **Default `scene_complexity = SINGLE_OBJECT`** is intentional placeholder, not a final value. This means until #13.2 ships, all 80 cases report as single_object in any "by complexity" group-by — that's expected and not a bug.
+
+## 7. References
+
+- **ADR-005** (`docs/DECISIONS.md`) — taxonomy decisions this PR implements
+- **GitHub #26** — `[#13.1] Schema: add SceneComplexity, tags, provenance, draft fields`
+- **Task list #24** — internal tracking
+- **#13.2 GitHub #27** — the next PR (audit pass) that depends on this
+- **PR-A merge commit** `4c1395d` — base for everything in this chain
+- **`ian/judge-empty-scene-guard`** merge commit `4157b65` — hard prerequisite
+  for #13.2 strict-mode flip-to-score; not directly required by #13.1

--- a/fixtures/starter_v3/ambiguous.json
+++ b/fixtures/starter_v3/ambiguous.json
@@ -14,20 +14,44 @@
         "Add an apple to the scene",
         "Build an apple using 3D primitives"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
       "style_intent": {
         "explicit": false,
         "concept": "apple",
-        "concept_aliases": ["fruit"],
-        "acceptable_styles": ["cartoon", "realistic", "low-poly", "stylized", "geometric"]
+        "concept_aliases": [
+          "fruit"
+        ],
+        "acceptable_styles": [
+          "cartoon",
+          "realistic",
+          "low-poly",
+          "stylized",
+          "geometric"
+        ]
       },
       "judge_policy": "score",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -41,23 +65,53 @@
         "Build a chair using primitives",
         "Model a chair"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "chair needs structure", "metric": "total_mesh_objects", "direction": "min",
-         "target": 1.0, "tolerance": 0.0, "weight": 0.5}
+        {
+          "name": "chair needs structure",
+          "metric": "total_mesh_objects",
+          "direction": "min",
+          "target": 1.0,
+          "tolerance": 0.0,
+          "weight": 0.5
+        }
       ],
       "style_intent": {
         "explicit": false,
         "concept": "chair",
-        "concept_aliases": ["seat", "furniture"],
-        "acceptable_styles": ["cartoon", "geometric", "low-poly", "realistic"]
+        "concept_aliases": [
+          "seat",
+          "furniture"
+        ],
+        "acceptable_styles": [
+          "cartoon",
+          "geometric",
+          "low-poly",
+          "realistic"
+        ]
       },
       "judge_policy": "score",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -71,15 +125,34 @@
         "Add any primitive mesh",
         "Put a shape in the scene"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": []},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": []
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -93,23 +166,54 @@
         "Build a house-shaped structure",
         "Model a simple house or building"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 2}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 2
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "house has multiple parts", "metric": "total_mesh_objects", "direction": "min",
-         "target": 2.0, "tolerance": 0.0, "weight": 0.5}
+        {
+          "name": "house has multiple parts",
+          "metric": "total_mesh_objects",
+          "direction": "min",
+          "target": 2.0,
+          "tolerance": 0.0,
+          "weight": 0.5
+        }
       ],
       "style_intent": {
         "explicit": false,
         "concept": "house",
-        "concept_aliases": ["building", "home", "structure"],
-        "acceptable_styles": ["cartoon", "geometric", "low-poly", "realistic"]
+        "concept_aliases": [
+          "building",
+          "home",
+          "structure"
+        ],
+        "acceptable_styles": [
+          "cartoon",
+          "geometric",
+          "low-poly",
+          "realistic"
+        ]
       },
       "judge_policy": "score",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -123,15 +227,34 @@
         "Be creative and add some objects",
         "Make an interesting 3D composition"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": []},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": []
+      },
       "judge_policy": "score",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/fixtures/starter_v3/compositional.json
+++ b/fixtures/starter_v3/compositional.json
@@ -14,18 +14,45 @@
         "Place a cube and a sphere in the scene",
         "Create two objects: a cube and a sphere"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 2}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 2
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "exactly two objects", "metric": "total_mesh_objects", "direction": "exact",
-         "target": 2.0, "tolerance": 1.0, "weight": 0.5}
+        {
+          "name": "exactly two objects",
+          "metric": "total_mesh_objects",
+          "direction": "exact",
+          "target": 2.0,
+          "tolerance": 1.0,
+          "weight": 0.5
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -39,18 +66,45 @@
         "Place three different primitives in the scene",
         "Add a cube, sphere, and cylinder to the scene"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 3}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 3
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "at least three objects", "metric": "total_mesh_objects", "direction": "min",
-         "target": 3.0, "tolerance": 1.0, "weight": 1.0}
+        {
+          "name": "at least three objects",
+          "metric": "total_mesh_objects",
+          "direction": "min",
+          "target": 3.0,
+          "tolerance": 1.0,
+          "weight": 1.0
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -64,27 +118,63 @@
         "Create two cubes, one stacked on the other",
         "Make a stack of two cubes"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
+      },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 2},
+        "mesh_object_count": {
+          "minimum": 2
+        },
         "bounding_boxes": [
           {
             "target": "__scene__",
             "size_range": {
-              "minimum": [1.5, 1.5, 3.5],
-              "maximum": [3.0, 3.0, 5.0]
+              "minimum": [
+                1.5,
+                1.5,
+                3.5
+              ],
+              "maximum": [
+                3.0,
+                3.0,
+                5.0
+              ]
             }
           }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "exactly two cubes", "metric": "total_mesh_objects", "direction": "exact",
-         "target": 2.0, "tolerance": 0.0, "weight": 0.5}
+        {
+          "name": "exactly two cubes",
+          "metric": "total_mesh_objects",
+          "direction": "exact",
+          "target": 2.0,
+          "tolerance": 0.0,
+          "weight": 0.5
+        }
       ],
-      "style_intent": {"explicit": false, "concept": "stack", "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "concept": "stack",
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "audit_only",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -98,23 +188,52 @@
         "Make a simple table with a flat top and four legs",
         "Construct a table from primitive shapes"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 2}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 2
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "table needs multiple parts", "metric": "total_mesh_objects", "direction": "min",
-         "target": 2.0, "tolerance": 1.0, "weight": 1.0}
+        {
+          "name": "table needs multiple parts",
+          "metric": "total_mesh_objects",
+          "direction": "min",
+          "target": 2.0,
+          "tolerance": 1.0,
+          "weight": 1.0
+        }
       ],
       "style_intent": {
         "explicit": false,
         "concept": "table",
-        "concept_aliases": ["desk", "furniture"],
-        "acceptable_styles": ["geometric", "cartoon", "low-poly"]
+        "concept_aliases": [
+          "desk",
+          "furniture"
+        ],
+        "acceptable_styles": [
+          "geometric",
+          "cartoon",
+          "low-poly"
+        ]
       },
       "judge_policy": "score",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -128,21 +247,48 @@
         "Compose a scene with 3 or more objects",
         "Create an arrangement of at least three 3D shapes"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 3}
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 3
+        }
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "multiple objects", "metric": "total_mesh_objects", "direction": "min",
-         "target": 3.0, "tolerance": 1.0, "weight": 1.0}
+        {
+          "name": "multiple objects",
+          "metric": "total_mesh_objects",
+          "direction": "min",
+          "target": 3.0,
+          "tolerance": 1.0,
+          "weight": 1.0
+        }
       ],
       "style_intent": {
         "explicit": false,
-        "acceptable_styles": ["geometric", "cartoon", "low-poly", "abstract"]
+        "acceptable_styles": [
+          "geometric",
+          "cartoon",
+          "low-poly",
+          "abstract"
+        ]
       },
       "judge_policy": "score",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/fixtures/starter_v3/materials.json
+++ b/fixtures/starter_v3/materials.json
@@ -16,19 +16,51 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
-      },
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "materials": [
-          {"target": "*", "base_color": [1.0, 0.0, 0.0, 1.0], "tolerance": 0.25}
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "materials": [
+          {
+            "target": "*",
+            "base_color": [
+              1.0,
+              0.0,
+              0.0,
+              1.0
+            ],
+            "tolerance": 0.25
+          }
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -44,19 +76,51 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "UV_SPHERE", "name": "Sphere"}]
-      },
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "materials": [
-          {"target": "*", "base_color": [0.0, 0.0, 1.0, 1.0], "tolerance": 0.25}
+        "objects": [
+          {
+            "primitive": "UV_SPHERE",
+            "name": "Sphere"
+          }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "materials": [
+          {
+            "target": "*",
+            "base_color": [
+              0.0,
+              0.0,
+              1.0,
+              1.0
+            ],
+            "tolerance": 0.25
+          }
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -72,19 +136,51 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
-      },
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "materials": [
-          {"target": "*", "base_color": [1.0, 1.0, 0.0, 1.0], "tolerance": 0.25}
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "materials": [
+          {
+            "target": "*",
+            "base_color": [
+              1.0,
+              1.0,
+              0.0,
+              1.0
+            ],
+            "tolerance": 0.25
+          }
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -100,19 +196,51 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CYLINDER", "name": "Cylinder"}]
-      },
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "materials": [
-          {"target": "*", "base_color": [0.0, 0.8, 0.0, 1.0], "tolerance": 0.3}
+        "objects": [
+          {
+            "primitive": "CYLINDER",
+            "name": "Cylinder"
+          }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "materials": [
+          {
+            "target": "*",
+            "base_color": [
+              0.0,
+              0.8,
+              0.0,
+              1.0
+            ],
+            "tolerance": 0.3
+          }
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -128,19 +256,51 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
-      },
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "materials": [
-          {"target": "*", "base_color": [1.0, 1.0, 1.0, 1.0], "tolerance": 0.15}
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "materials": [
+          {
+            "target": "*",
+            "base_color": [
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "tolerance": 0.15
+          }
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/fixtures/starter_v3/object_creation.json
+++ b/fixtures/starter_v3/object_creation.json
@@ -14,19 +14,49 @@
         "Place a cube in the scene",
         "Add a box shape"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "required_object_types": ["MESH"]
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": true, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "required_object_types": [
+          "MESH"
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": true,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "single mesh object", "metric": "total_mesh_objects", "direction": "exact",
-         "target": 1.0, "tolerance": 0.0, "weight": 1.0}
+        {
+          "name": "single mesh object",
+          "metric": "total_mesh_objects",
+          "direction": "exact",
+          "target": 1.0,
+          "tolerance": 0.0,
+          "weight": 1.0
+        }
       ],
-      "style_intent": {"explicit": false, "concept": "cube", "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "concept": "cube",
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -40,27 +70,67 @@
         "Place a large sphere with radius 2m in the scene",
         "Add a ball with radius of 2 meters"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
+      },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
+        "mesh_object_count": {
+          "minimum": 1
+        },
         "bounding_boxes": [
           {
             "target": "__scene__",
             "size_range": {
-              "minimum": [3.5, 3.5, 3.5],
-              "maximum": [4.5, 4.5, 4.5]
+              "minimum": [
+                3.5,
+                3.5,
+                3.5
+              ],
+              "maximum": [
+                4.5,
+                4.5,
+                4.5
+              ]
             }
           }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0, "max_vertex_count": 50000},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0,
+        "max_vertex_count": 50000
+      },
       "soft_constraints": [
-        {"name": "sphere vertex count reasonable", "metric": "total_vertices", "direction": "min",
-         "target": 50.0, "tolerance": 20.0, "weight": 0.5}
+        {
+          "name": "sphere vertex count reasonable",
+          "metric": "total_vertices",
+          "direction": "min",
+          "target": 50.0,
+          "tolerance": 20.0,
+          "weight": 0.5
+        }
       ],
-      "style_intent": {"explicit": false, "concept": "sphere", "concept_aliases": ["ball"], "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "concept": "sphere",
+        "concept_aliases": [
+          "ball"
+        ],
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -74,24 +144,54 @@
         "Make a cylindrical shape, radius 1m height 3m",
         "Add a tall cylinder: radius=1, depth=3"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
+      },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
+        "mesh_object_count": {
+          "minimum": 1
+        },
         "bounding_boxes": [
           {
             "target": "__scene__",
             "size_range": {
-              "minimum": [1.5, 1.5, 2.5],
-              "maximum": [2.5, 2.5, 3.5]
+              "minimum": [
+                1.5,
+                1.5,
+                2.5
+              ],
+              "maximum": [
+                2.5,
+                2.5,
+                3.5
+              ]
             }
           }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "concept": "cylinder", "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "concept": "cylinder",
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -105,16 +205,40 @@
         "Place an icospheric mesh in the scene",
         "Add an icosahedron sphere"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "required_object_types": ["MESH"]
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": true, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "required_object_types": [
+          "MESH"
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": true,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "concept": "sphere", "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "concept": "sphere",
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -128,19 +252,53 @@
         "Place a donut-shaped mesh in the scene",
         "Add a torus primitive"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "required_object_types": ["MESH"]
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": true, "quad_ratio_min": 0.7},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "required_object_types": [
+          "MESH"
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": true,
+        "quad_ratio_min": 0.7
+      },
       "soft_constraints": [
-        {"name": "torus vertex count", "metric": "total_vertices", "direction": "min",
-         "target": 50.0, "tolerance": 20.0, "weight": 0.5}
+        {
+          "name": "torus vertex count",
+          "metric": "total_vertices",
+          "direction": "min",
+          "target": 50.0,
+          "tolerance": 20.0,
+          "weight": 0.5
+        }
       ],
-      "style_intent": {"explicit": false, "concept": "torus", "concept_aliases": ["donut", "ring"], "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "concept": "torus",
+        "concept_aliases": [
+          "donut",
+          "ring"
+        ],
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/fixtures/starter_v3/safety.json
+++ b/fixtures/starter_v3/safety.json
@@ -16,16 +16,37 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
+        ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"maximum": 0}
+        "mesh_object_count": {
+          "maximum": 0
+        }
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": []},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": []
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": false, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": false,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -42,18 +63,40 @@
       "initial_scene": {
         "mode": "OBJECT",
         "objects": [
-          {"primitive": "CUBE", "name": "Cube"},
-          {"primitive": "UV_SPHERE", "name": "Sphere"}
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          },
+          {
+            "primitive": "UV_SPHERE",
+            "name": "Sphere"
+          }
         ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"maximum": 0}
+        "mesh_object_count": {
+          "maximum": 0
+        }
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": []},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": []
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": false, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": false,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -67,16 +110,39 @@
         "The scene is empty — add a cube",
         "Start fresh and add a default cube"
       ],
-      "initial_scene": {"mode": "OBJECT", "objects": []},
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
-        "required_object_types": ["MESH"]
+      "initial_scene": {
+        "mode": "OBJECT",
+        "objects": []
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 1
+        },
+        "required_object_types": [
+          "MESH"
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -92,27 +158,71 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube", "location": [-2.0, 0.0, 0.0]}]
-      },
-      "hard_constraints": {
-        "mesh_object_count": {"minimum": 2},
-        "required_named_objects": ["Cube"],
-        "scene_mutation": {"preserve_seed_objects": true},
-        "bounding_boxes": [
+        "objects": [
           {
-            "target": "__scene__",
-            "size_range": {"minimum": [3.0, 0.0, 0.0]}
+            "primitive": "CUBE",
+            "name": "Cube",
+            "location": [
+              -2.0,
+              0.0,
+              0.0
+            ]
           }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "hard_constraints": {
+        "mesh_object_count": {
+          "minimum": 2
+        },
+        "required_named_objects": [
+          "Cube"
+        ],
+        "scene_mutation": {
+          "preserve_seed_objects": true
+        },
+        "bounding_boxes": [
+          {
+            "target": "__scene__",
+            "size_range": {
+              "minimum": [
+                3.0,
+                0.0,
+                0.0
+              ]
+            }
+          }
+        ]
+      },
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "exactly two objects", "metric": "total_mesh_objects", "direction": "exact",
-         "target": 2.0, "tolerance": 0.0, "weight": 0.5}
+        {
+          "name": "exactly two objects",
+          "metric": "total_mesh_objects",
+          "direction": "exact",
+          "target": 2.0,
+          "tolerance": 0.0,
+          "weight": 0.5
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -129,22 +239,55 @@
       "initial_scene": {
         "mode": "OBJECT",
         "objects": [
-          {"primitive": "CUBE", "name": "Cube"},
-          {"primitive": "CYLINDER", "name": "Cylinder"}
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          },
+          {
+            "primitive": "CYLINDER",
+            "name": "Cylinder"
+          }
         ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1, "maximum": 1},
-        "required_object_types": ["MESH"]
+        "mesh_object_count": {
+          "minimum": 1,
+          "maximum": 1
+        },
+        "required_object_types": [
+          "MESH"
+        ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "exactly one object after reset", "metric": "total_mesh_objects", "direction": "exact",
-         "target": 1.0, "tolerance": 0.0, "weight": 1.0}
+        {
+          "name": "exactly one object after reset",
+          "metric": "total_mesh_objects",
+          "direction": "exact",
+          "target": 1.0,
+          "tolerance": 0.0,
+          "weight": 1.0
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/fixtures/starter_v3/transformations.json
+++ b/fixtures/starter_v3/transformations.json
@@ -16,28 +16,65 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
+        ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
+        "mesh_object_count": {
+          "minimum": 1
+        },
         "bounding_boxes": [
           {
             "target": "__scene__",
             "size_range": {
-              "minimum": [3.5, 3.5, 3.5],
-              "maximum": [4.5, 4.5, 4.5]
+              "minimum": [
+                3.5,
+                3.5,
+                3.5
+              ],
+              "maximum": [
+                4.5,
+                4.5,
+                4.5
+              ]
             }
           }
         ]
       },
-      "topology_policy": {"manifold_required": true, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": true,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "single object preserved", "metric": "total_mesh_objects", "direction": "exact",
-         "target": 1.0, "tolerance": 0.0, "weight": 0.5}
+        {
+          "name": "single object preserved",
+          "metric": "total_mesh_objects",
+          "direction": "exact",
+          "target": 1.0,
+          "tolerance": 0.0,
+          "weight": 0.5
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -53,25 +90,56 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
+        ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
+        "mesh_object_count": {
+          "minimum": 1
+        },
         "bounding_boxes": [
           {
             "target": "__scene__",
             "size_range": {
-              "minimum": [5.0, 1.5, 1.5],
-              "maximum": [7.0, 2.5, 2.5]
+              "minimum": [
+                5.0,
+                1.5,
+                1.5
+              ],
+              "maximum": [
+                7.0,
+                2.5,
+                2.5
+              ]
             }
           }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -87,21 +155,56 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
+        ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+        "mesh_object_count": {
+          "minimum": 1
+        }
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "bevel adds geometry", "metric": "total_vertices", "direction": "min",
-         "target": 24.0, "tolerance": 8.0, "weight": 1.0},
-        {"name": "more faces after bevel", "metric": "total_faces", "direction": "min",
-         "target": 20.0, "tolerance": 6.0, "weight": 1.0}
+        {
+          "name": "bevel adds geometry",
+          "metric": "total_vertices",
+          "direction": "min",
+          "target": 24.0,
+          "tolerance": 8.0,
+          "weight": 1.0
+        },
+        {
+          "name": "more faces after bevel",
+          "metric": "total_faces",
+          "direction": "min",
+          "target": 20.0,
+          "tolerance": 6.0,
+          "weight": 1.0
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -117,28 +220,65 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
+        ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1},
+        "mesh_object_count": {
+          "minimum": 1
+        },
         "bounding_boxes": [
           {
             "target": "__scene__",
             "size_range": {
-              "minimum": [1.5, 1.5, 2.5],
-              "maximum": [2.5, 2.5, 4.5]
+              "minimum": [
+                1.5,
+                1.5,
+                2.5
+              ],
+              "maximum": [
+                2.5,
+                2.5,
+                4.5
+              ]
             }
           }
         ]
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "extrusion adds faces", "metric": "total_faces", "direction": "min",
-         "target": 10.0, "tolerance": 2.0, "weight": 1.0}
+        {
+          "name": "extrusion adds faces",
+          "metric": "total_faces",
+          "direction": "min",
+          "target": 10.0,
+          "tolerance": 2.0,
+          "weight": 1.0
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -154,21 +294,56 @@
       ],
       "initial_scene": {
         "mode": "OBJECT",
-        "objects": [{"primitive": "CUBE", "name": "Cube"}]
+        "objects": [
+          {
+            "primitive": "CUBE",
+            "name": "Cube"
+          }
+        ]
       },
       "hard_constraints": {
-        "mesh_object_count": {"minimum": 1}
+        "mesh_object_count": {
+          "minimum": 1
+        }
       },
-      "topology_policy": {"manifold_required": false, "quad_ratio_min": 0.0},
+      "topology_policy": {
+        "manifold_required": false,
+        "quad_ratio_min": 0.0
+      },
       "soft_constraints": [
-        {"name": "complex geometry from two ops", "metric": "total_vertices", "direction": "min",
-         "target": 30.0, "tolerance": 10.0, "weight": 1.0},
-        {"name": "many faces", "metric": "total_faces", "direction": "min",
-         "target": 25.0, "tolerance": 8.0, "weight": 1.0}
+        {
+          "name": "complex geometry from two ops",
+          "metric": "total_vertices",
+          "direction": "min",
+          "target": 30.0,
+          "tolerance": 10.0,
+          "weight": 1.0
+        },
+        {
+          "name": "many faces",
+          "metric": "total_faces",
+          "direction": "min",
+          "target": 25.0,
+          "tolerance": 8.0,
+          "weight": 1.0
+        }
       ],
-      "style_intent": {"explicit": false, "acceptable_styles": ["geometric"]},
+      "style_intent": {
+        "explicit": false,
+        "acceptable_styles": [
+          "geometric"
+        ]
+      },
       "judge_policy": "skip",
-      "artifact_policy": {"require_screenshot": true, "write_scene_stats": true}
+      "artifact_policy": {
+        "require_screenshot": true,
+        "write_scene_stats": true
+      },
+      "scene_complexity": "single_object",
+      "provenance": "handcrafted",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/fixtures/synthetic/generated_primitive_cases.json
+++ b/fixtures/synthetic/generated_primitive_cases.json
@@ -51,7 +51,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -102,7 +107,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -153,7 +163,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -204,7 +219,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -255,7 +275,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -310,7 +335,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -365,7 +395,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -420,7 +455,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -475,7 +515,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -530,7 +575,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -585,7 +635,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -640,7 +695,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -695,7 +755,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -750,7 +815,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -805,7 +875,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -860,7 +935,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -915,7 +995,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -970,7 +1055,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1025,7 +1115,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1080,7 +1175,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1135,7 +1235,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1190,7 +1295,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1245,7 +1355,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1300,7 +1415,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1355,7 +1475,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1410,7 +1535,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1465,7 +1595,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1520,7 +1655,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1575,7 +1715,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1630,7 +1775,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1685,7 +1835,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1740,7 +1895,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1795,7 +1955,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1850,7 +2015,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1905,7 +2075,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -1960,7 +2135,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2015,7 +2195,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2070,7 +2255,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2125,7 +2315,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2180,7 +2375,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2235,7 +2435,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2290,7 +2495,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2345,7 +2555,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2400,7 +2615,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2455,7 +2675,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2510,7 +2735,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2565,7 +2795,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2620,7 +2855,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2675,7 +2915,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     },
     {
       "fixture_version": "3.0",
@@ -2730,7 +2975,12 @@
       "artifact_policy": {
         "require_screenshot": true,
         "write_scene_stats": true
-      }
+      },
+      "scene_complexity": "single_object",
+      "provenance": "synthetic",
+      "tags": [
+        "canonical"
+      ]
     }
   ]
 }

--- a/nalana_eval/schema.py
+++ b/nalana_eval/schema.py
@@ -28,9 +28,51 @@ class Category(str, Enum):
 
 
 class Difficulty(str, Enum):
+    """⚠ DEPRECATED — see ADR-005. Removal targeted at v3.2.
+
+    Conflated three independent dimensions (prompt verbosity / scene complexity /
+    judgment difficulty). Replaced by SceneComplexity (manually authored, captures
+    output-shape intent). Existing fixtures keep populating this for one cycle to
+    avoid breaking downstream code; new fixtures (#13.3+) should not set it.
+    """
     SHORT = "Short"
     MEDIUM = "Medium"
     LONG = "Long"
+
+
+class SceneComplexity(str, Enum):
+    """ADR-005 — replaces Difficulty as the primary case-shape axis.
+
+    Reflects AUTHOR INTENT for the output scene; not auto-derived from
+    constraint shape (the decoupling lets drift_check #13.4 catch
+    label-vs-constraint inconsistencies that auto-derivation would silence).
+    """
+    SINGLE_OBJECT = "single_object"   # 1 mesh
+    MULTI_OBJECT  = "multi_object"    # 2-5 mesh, no spatial relationships required
+    COMPOSITION   = "composition"     # 2+ mesh; author intends spatial structure
+                                      # (e.g., table = top above legs); enforcement
+                                      # is the L3 judge's job, NOT hard relative_positions
+    FULL_SCENE    = "full_scene"      # 5+ mesh + materials, complete environment
+
+
+class Provenance(str, Enum):
+    """Where this case came from. Used by reports + drift_check + slate composition."""
+    HANDCRAFTED  = "handcrafted"   # human-authored (starter_v3/*)
+    SYNTHETIC    = "synthetic"     # programmatic generator (synthetic/*)
+    LLM_AUTHORED = "llm_authored"  # LLM drafting pipeline (#13.3+)
+
+
+class Tag(str, Enum):
+    """Orthogonal categorical labels (independent of SceneComplexity / Provenance).
+
+    The enum can grow; new values land alongside the use case that needs them
+    (e.g., 'multi_object' / 'edit' / 'stylized' may show up later — they're
+    semantically OK to delegate to SceneComplexity for now).
+    """
+    CANONICAL   = "canonical"     # standard baseline test
+    ADVERSARIAL = "adversarial"   # deliberately stress-testing edge cases
+    AMBIGUOUS   = "ambiguous"     # prompt intentionally underspecified
+    HONEYPOT    = "honeypot"      # deliberately failing case (judge-reliability check)
 
 
 class TaskFamily(str, Enum):
@@ -461,7 +503,12 @@ class TestCaseCard(BaseModel):
     fixture_version: str = FIXTURE_VERSION
     id: str
     category: Category
-    difficulty: Difficulty
+    # `difficulty` is DEPRECATED per ADR-005; kept Optional one cycle for back-compat.
+    # New axis is `scene_complexity` (manually authored, captures author intent for
+    # output shape). Existing 80 fixtures continue to populate `difficulty` until
+    # v3.2 removal.
+    difficulty: Optional[Difficulty] = None
+    scene_complexity: SceneComplexity = SceneComplexity.SINGLE_OBJECT
     task_family: TaskFamily
     prompt_variants: List[str] = Field(..., min_length=1)
     initial_scene: InitialScene = Field(default_factory=InitialScene)
@@ -471,6 +518,13 @@ class TestCaseCard(BaseModel):
     style_intent: StyleIntent = Field(default_factory=StyleIntent)
     judge_policy: JudgePolicy = JudgePolicy.SCORE
     artifact_policy: ArtifactPolicy = Field(default_factory=ArtifactPolicy)
+    # Provenance / draft / tags introduced in #13.1 to support the authoring
+    # pipeline (LLM drafting, drift check, sampling human review).  Existing
+    # 80 fixtures get backfilled mechanically (provenance by directory,
+    # tags=["canonical"]).  See ADR-005.
+    provenance: Provenance = Provenance.HANDCRAFTED
+    draft: bool = False
+    tags: List[Tag] = Field(default_factory=list)
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("prompt_variants")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -20,6 +20,8 @@ from nalana_eval.schema import (
     JudgeResult,
     MaterialConstraint,
     NormalizedStep,
+    Provenance,
+    SceneComplexity,
     SceneMeshSnapshot,
     SceneSnapshot,
     SceneSeed,
@@ -28,6 +30,7 @@ from nalana_eval.schema import (
     SoftMetric,
     StepKind,
     StyleIntent,
+    Tag,
     TaskFamily,
     TestCaseCard,
     TestSuite,
@@ -240,6 +243,91 @@ def test_test_case_card_unknown_field_rejected():
 def test_test_case_card_judge_policy_skip():
     case = TestCaseCard.model_validate(_minimal_case(judge_policy="skip"))
     assert case.judge_policy == JudgePolicy.SKIP
+
+
+# ---------------------------------------------------------------------------
+# ADR-005: SceneComplexity / Provenance / Tag / draft / deprecated Difficulty
+# ---------------------------------------------------------------------------
+
+
+def test_scene_complexity_default_is_single_object():
+    """If a fixture omits scene_complexity, it defaults to SINGLE_OBJECT.
+    This is the safe default used for mechanical backfill in #13.1; #13.2 fixes wrong tags."""
+    case = TestCaseCard.model_validate(_minimal_case())
+    assert case.scene_complexity == SceneComplexity.SINGLE_OBJECT
+
+
+def test_scene_complexity_explicit_value():
+    case = TestCaseCard.model_validate(_minimal_case(scene_complexity="composition"))
+    assert case.scene_complexity == SceneComplexity.COMPOSITION
+
+
+def test_scene_complexity_invalid_value_rejected():
+    with pytest.raises(ValidationError):
+        TestCaseCard.model_validate(_minimal_case(scene_complexity="not_a_real_value"))
+
+
+def test_provenance_default_is_handcrafted():
+    case = TestCaseCard.model_validate(_minimal_case())
+    assert case.provenance == Provenance.HANDCRAFTED
+
+
+def test_provenance_synthetic():
+    case = TestCaseCard.model_validate(_minimal_case(provenance="synthetic"))
+    assert case.provenance == Provenance.SYNTHETIC
+
+
+def test_provenance_llm_authored():
+    case = TestCaseCard.model_validate(_minimal_case(provenance="llm_authored"))
+    assert case.provenance == Provenance.LLM_AUTHORED
+
+
+def test_tags_default_is_empty_list():
+    """Default empty list — fixtures get backfilled with ['canonical'] by #13.1 script."""
+    case = TestCaseCard.model_validate(_minimal_case())
+    assert case.tags == []
+
+
+def test_tags_canonical_explicit():
+    case = TestCaseCard.model_validate(_minimal_case(tags=["canonical"]))
+    assert Tag.CANONICAL in case.tags
+
+
+def test_tags_multiple():
+    case = TestCaseCard.model_validate(_minimal_case(tags=["canonical", "adversarial"]))
+    assert set(case.tags) == {Tag.CANONICAL, Tag.ADVERSARIAL}
+
+
+def test_tags_invalid_rejected():
+    with pytest.raises(ValidationError):
+        TestCaseCard.model_validate(_minimal_case(tags=["not_a_real_tag"]))
+
+
+def test_draft_default_is_false():
+    case = TestCaseCard.model_validate(_minimal_case())
+    assert case.draft is False
+
+
+def test_draft_true_for_llm_drafts():
+    """LLM-authored cases are marked draft=True until human review (#13.6)."""
+    payload = _minimal_case(provenance="llm_authored", draft=True)
+    case = TestCaseCard.model_validate(payload)
+    assert case.draft is True
+    assert case.provenance == Provenance.LLM_AUTHORED
+
+
+def test_difficulty_now_optional():
+    """Per ADR-005, Difficulty is deprecated and Optional. Cases can omit it."""
+    payload = _minimal_case()
+    payload.pop("difficulty", None)
+    case = TestCaseCard.model_validate(payload)
+    assert case.difficulty is None
+
+
+def test_difficulty_still_accepts_legacy_values():
+    """Existing 80 fixtures still set difficulty during the deprecation cycle."""
+    case = TestCaseCard.model_validate(_minimal_case(difficulty="Long"))
+    assert case.difficulty == Difficulty.LONG
 
 
 def test_test_case_card_full():


### PR DESCRIPTION
…ADR-005

Implements ADR-005's schema-level decisions:
- New SceneComplexity enum (single_object / multi_object / composition / full_scene) replacing the conflated Difficulty axis (kept Optional for back-compat one cycle)
- New Provenance enum (handcrafted / synthetic / llm_authored) for case-source tracking
- New Tag enum (canonical / adversarial / ambiguous / honeypot) for orthogonal labels
- New 'draft: bool = False' field for marking unreviewed LLM-authored cases

Existing 80 fixtures backfilled mechanically:
- scene_complexity = 'single_object' (placeholder; #15.2 audit corrects ~10-15)
- provenance = 'handcrafted' for starter_v3/* cases; 'synthetic' for synthetic/*
- tags = ['canonical'] for all (baseline-vs-new distinction)

Tests: 14 new unit tests in tests/test_schema.py covering each new enum value, defaults, validation (rejection of invalid values), and Difficulty deprecation back-compat.

Side cleanup: docs/handoffs/2026-04-29-post-merge-cleanup.md status flipped in_progress → shipped (PR-A merged 2026-04-30; this is one of #21's bundled follow-ups).

ADR-003 compliant: single concern (ADR-005 schema implementation + its mechanically-derivable fixture backfill). Audit pass that corrects wrong default values is deferred to #15.2 (separate PR per ADR-005 Q4-A decision).

Closes GitHub #26.
Refs: ADR-005, Task #15.1, Task #24 , #15.2 (next, GitHub #27 ).