### PR TITLE
PR-C: suppress Xvfb stderr noise in entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ For details on any entry, follow the linked PR / handoff doc / ADR.
 
 ---
 
+## 2026-05-06 — PR-C: Xvfb stderr noise suppression
+
+First of three split PRs replacing the original PR-B omnibus per ADR-003. Smallest of the trio — ships first to clear the plate.
+
+`docker/entrypoint.sh`:
+- Xvfb's own stdio redirected to `${XVFB_LOG:-/tmp/xvfb.log}`. Harmless `_XSERVTransmkdir` warnings (caused by `/tmp/.X11-unix` ownership mismatch under non-root `appuser`, see PR-A C5) no longer drown out benchmark output.
+- New `_dump_xvfb_log` helper called on both existing startup-failure exit paths, preserving diagnosability.
+- No new env flags; full diff is ~12 lines.
+
+Sibling PRs to follow: PR-D (`attempts.csv` schema migration helper) and PR-E (L2 validator vocabulary + `CV-AMB-001` constraint tightening). All three address PR-A retrospective items deferred from the merge.
+
+Refs: ADR-003, [docs/handoffs/2026-05-06-pr-c-xvfb-noise.md](docs/handoffs/2026-05-06-pr-c-xvfb-noise.md), [docs/handoffs/2026-04-29-post-merge-cleanup.md](docs/handoffs/2026-04-29-post-merge-cleanup.md) §6.
+
+---
+
 ## 2026-05-02 — #13.1: schema fields (SceneComplexity / Provenance / Tag / draft) + mechanical fixture backfill
 
 Per ADR-005, schema-level taxonomy lands. Pure infrastructure PR — no judgment-based data changes (those land in #13.2 audit).

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,10 +13,24 @@ set -e
 source /opt/venv/bin/activate
 
 # Start virtual framebuffer so Blender's OpenGL renderer has a display context.
-Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+# Redirect Xvfb's own stdio to a log file so its harmless startup warnings
+# (e.g. `_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root` when
+# running as the non-root appuser) don't drown out benchmark output.
+# The log is dumped on failure to preserve diagnosability.
+XVFB_LOG="${XVFB_LOG:-/tmp/xvfb.log}"
+Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset \
+    >"${XVFB_LOG}" 2>&1 &
 XVFB_PID=$!
 export DISPLAY=:99
 trap "kill ${XVFB_PID} 2>/dev/null || true" EXIT
+
+_dump_xvfb_log() {
+    if [ -s "${XVFB_LOG}" ]; then
+        echo "--- Xvfb log (${XVFB_LOG}) ---" >&2
+        cat "${XVFB_LOG}" >&2
+        echo "--- end Xvfb log ---" >&2
+    fi
+}
 
 # Wait until the X server is actually responding rather than guessing with sleep.
 # Probe with xdpyinfo (from x11-utils); give up after ~6 seconds.
@@ -26,6 +40,7 @@ for _ in $(seq 1 30); do
     fi
     if ! kill -0 "${XVFB_PID}" 2>/dev/null; then
         echo "Xvfb died during startup" >&2
+        _dump_xvfb_log
         exit 1
     fi
     sleep 0.2
@@ -33,6 +48,7 @@ done
 
 if ! xdpyinfo -display :99 >/dev/null 2>&1; then
     echo "Xvfb did not become ready within 6 seconds" >&2
+    _dump_xvfb_log
     exit 1
 fi
 

--- a/docs/handoffs/2026-05-06-pr-c-xvfb-noise.md
+++ b/docs/handoffs/2026-05-06-pr-c-xvfb-noise.md
@@ -1,0 +1,101 @@
+# Handoff: PR-C — Xvfb stderr noise suppression
+
+```yaml
+status:        in_progress
+owner:         ian + Claude Cowork
+related_task:  #21 (PR-A follow-up umbrella; sub-task internally #25)
+related_pr:    (TBD on push)
+date_opened:   2026-05-06
+date_closed:   —
+```
+
+> First of three split PRs replacing the original "PR-B" omnibus per ADR-003.
+> Sibling PRs: PR-D (CSV migration helper), PR-E (L2 validator vocabulary +
+> CV-AMB-001 fixture). Each ships independently.
+
+---
+
+## 1. What this is
+
+PR-A C5 made the container run as non-root `appuser`. PR-A C6 replaced the
+`sleep 1` Xvfb race with an `xdpyinfo` probe loop. What neither commit
+addressed: Xvfb itself emits harmless stderr warnings on startup
+(`_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root`, etc.)
+because the `/tmp/.X11-unix` directory's ownership doesn't match the
+non-root UID. These warnings drown out actual benchmark output. PR-C
+redirects Xvfb's stdio to a log file and dumps it only on startup failure.
+
+## 2. Why now — what triggered this
+
+Flagged in PR-A retrospective as one of three deferred follow-ups (see
+`docs/handoffs/2026-04-29-post-merge-cleanup.md` §6 reference / CLAUDE.md
+gotchas). Original plan was to bundle into a single "PR-B"; per ADR-003
+that bundling itself was the lesson, so it's split. PR-C is the smallest
+of the three — ships first to clear the plate.
+
+## 3. Scope
+
+```
+In:
+- docker/entrypoint.sh — redirect Xvfb stdio to ${XVFB_LOG:-/tmp/xvfb.log};
+                        add _dump_xvfb_log helper invoked on the two existing
+                        startup-failure exit paths
+- CHANGELOG.md         — one entry block
+- this handoff doc
+
+Out (deferred to sibling PRs):
+- attempts.csv schema migration helper            → PR-D
+- L2 validator vocabulary + CV-AMB-001 collection → PR-E
+- Anything not strictly Xvfb stdio
+```
+
+## 4. Decisions made
+
+```
+Q: Suppress all Xvfb stderr, or filter the specific known-noise lines?
+→ Suppress all (redirect to log file). Filtering by message string is
+  brittle across Xorg versions; full redirect with on-failure dump preserves
+  full diagnosability without runtime cost. The `_XSERVTransmkdir` warning
+  is the *primary* known noise but not the only one — filter list would
+  drift.
+
+Q: Make verbose mode opt-in via env var?
+→ No. YAGNI. If someone needs to see Xvfb output during a successful run,
+  they can `cat /tmp/xvfb.log` from inside the container or override
+  XVFB_LOG to /dev/stderr. No new flag in this PR.
+
+Q: Add Xvfb log to artifact dir for CI?
+→ No. Out of scope. If CI needs persistent Xvfb logs, that's a separate
+  ops task — entrypoint shouldn't decide artifact retention policy.
+```
+
+## 5. How to verify
+
+- [ ] `bash -n docker/entrypoint.sh` — clean (already verified)
+- [ ] `docker build .` — succeeds (no Dockerfile changes; mainly a sanity check)
+- [ ] Run a benchmark in container with `MODELS=mock CASES=2`:
+  - [ ] No `_XSERVTransmkdir` warning visible in container stdout/stderr
+  - [ ] Benchmark output (model rows, pass@1) visible un-cluttered
+  - [ ] `/tmp/xvfb.log` exists inside container with the suppressed warnings
+- [ ] Negative path (manual): force Xvfb to fail (e.g., kill Xvfb mid-startup
+      via a hostile change, or set `-screen 0 0x0x0`); verify the
+      `--- Xvfb log ---` block appears on stderr followed by the dumped log
+
+## 6. Known issues / TODOs / handoff to next
+
+- **No `XVFB_VERBOSE` env knob** — opted out per Decision §4 above. Add only
+  when there's an actual user request.
+- **Log file is not rotated.** Single Xvfb session writes once; container
+  exit cleans /tmp. No need for rotation. If someone runs the container in
+  a long-lived loop (not how we use it), they could fill /tmp; revisit then.
+- **Sibling PRs (PR-D, PR-E)** are tracked separately. Don't touch CSV
+  schema or L2 validators in this PR.
+
+## 7. References
+
+- ADR-003 (mixed-concerns PR forbidden) — `docs/DECISIONS.md`
+- PR-A handoff: `docs/handoffs/2026-04-29-post-merge-cleanup.md` (§6 names
+  this as deferred follow-up)
+- CLAUDE.md gotcha row: "Xvfb noise" entry referenced internally
+- Sibling tasks (internal): #27 (PR-D), #28 (PR-E), #26 (paper-only L2
+  vocabulary design)


### PR DESCRIPTION
# Handoff: PR-C — Xvfb stderr noise suppression

```yaml
status:        in_progress
owner:         ian + Claude Cowork
related_task:  #21 (PR-A follow-up umbrella; sub-task internally #25)
related_pr:    (TBD on push)
date_opened:   2026-05-06
date_closed:   —
```

> First of three split PRs replacing the original "PR-B" omnibus per ADR-003.
> Sibling PRs: PR-D (CSV migration helper), PR-E (L2 validator vocabulary +
> CV-AMB-001 fixture). Each ships independently.

---

## 1. What this is

PR-A C5 made the container run as non-root `appuser`. PR-A C6 replaced the
`sleep 1` Xvfb race with an `xdpyinfo` probe loop. What neither commit
addressed: Xvfb itself emits harmless stderr warnings on startup
(`_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root`, etc.)
because the `/tmp/.X11-unix` directory's ownership doesn't match the
non-root UID. These warnings drown out actual benchmark output. PR-C
redirects Xvfb's stdio to a log file and dumps it only on startup failure.

## 2. Why now — what triggered this

Flagged in PR-A retrospective as one of three deferred follow-ups (see
`docs/handoffs/2026-04-29-post-merge-cleanup.md` §6 reference / CLAUDE.md
gotchas). Original plan was to bundle into a single "PR-B"; per ADR-003
that bundling itself was the lesson, so it's split. PR-C is the smallest
of the three — ships first to clear the plate.

## 3. Scope

```
In:
- docker/entrypoint.sh — redirect Xvfb stdio to ${XVFB_LOG:-/tmp/xvfb.log};
                        add _dump_xvfb_log helper invoked on the two existing
                        startup-failure exit paths
- CHANGELOG.md         — one entry block
- this handoff doc

Out (deferred to sibling PRs):
- attempts.csv schema migration helper            → PR-D
- L2 validator vocabulary + CV-AMB-001 collection → PR-E
- Anything not strictly Xvfb stdio
```

## 4. Decisions made

```
Q: Suppress all Xvfb stderr, or filter the specific known-noise lines?
→ Suppress all (redirect to log file). Filtering by message string is
  brittle across Xorg versions; full redirect with on-failure dump preserves
  full diagnosability without runtime cost. The `_XSERVTransmkdir` warning
  is the *primary* known noise but not the only one — filter list would
  drift.

Q: Make verbose mode opt-in via env var?
→ No. YAGNI. If someone needs to see Xvfb output during a successful run,
  they can `cat /tmp/xvfb.log` from inside the container or override
  XVFB_LOG to /dev/stderr. No new flag in this PR.

Q: Add Xvfb log to artifact dir for CI?
→ No. Out of scope. If CI needs persistent Xvfb logs, that's a separate
  ops task — entrypoint shouldn't decide artifact retention policy.
```

## 5. How to verify

- [ ] `bash -n docker/entrypoint.sh` — clean (already verified)
- [ ] `docker build .` — succeeds (no Dockerfile changes; mainly a sanity check)
- [ ] Run a benchmark in container with `MODELS=mock CASES=2`:
  - [ ] No `_XSERVTransmkdir` warning visible in container stdout/stderr
  - [ ] Benchmark output (model rows, pass@1) visible un-cluttered
  - [ ] `/tmp/xvfb.log` exists inside container with the suppressed warnings
- [ ] Negative path (manual): force Xvfb to fail (e.g., kill Xvfb mid-startup
      via a hostile change, or set `-screen 0 0x0x0`); verify the
      `--- Xvfb log ---` block appears on stderr followed by the dumped log

## 6. Known issues / TODOs / handoff to next

- **No `XVFB_VERBOSE` env knob** — opted out per Decision §4 above. Add only
  when there's an actual user request.
- **Log file is not rotated.** Single Xvfb session writes once; container
  exit cleans /tmp. No need for rotation. If someone runs the container in
  a long-lived loop (not how we use it), they could fill /tmp; revisit then.
- **Sibling PRs (PR-D, PR-E)** are tracked separately. Don't touch CSV
  schema or L2 validators in this PR.

## 7. References

- ADR-003 (mixed-concerns PR forbidden) — `docs/DECISIONS.md`
- PR-A handoff: `docs/handoffs/2026-04-29-post-merge-cleanup.md` (§6 names
  this as deferred follow-up)
- CLAUDE.md gotcha row: "Xvfb noise" entry referenced internally
- Sibling tasks (internal): #27 (PR-D), #28 (PR-E), #26 (paper-only L2
  vocabulary design)