### PR TITLE
PR-H: pre-commit hook + AI commit recipe rule (git-risk hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ For details on any entry, follow the linked PR / handoff doc / ADR.
 
 ---
 
+## 2026-05-06 — PR-H: git-risk hardening (pre-commit hook + AI verify-branch rule)
+
+Tier 1 preventive tooling for the class of mistakes that cost ~30 min × 3 in this session: commits landing on the wrong branch because `git checkout -b` was forgotten or paste lost the branch-create step. The cleanup-via-cherry-pick path was always the same and always avoidable.
+
+New tooling:
+- `scripts/git-hooks/pre-commit` — refuses commits on `main` / `master` with a help message pointing to `git checkout -b`. Bypass with `git commit --no-verify` for emergencies.
+- `scripts/setup-git-hooks.sh` — idempotent installer; copies repo-tracked hooks into `.git/hooks/`. Per-clone setup since hooks aren't git-tracked. Brian + future contributors should run this once.
+
+`CLAUDE.md` updates:
+- New gotcha row pointing to the hook setup.
+- New sub-rule under "Sync before reasoning about git state": **AI commit recipe always verifies branch first** — every command sequence containing `git add` / `git commit` MUST start with `git branch --show-current` and `git status -sb` as separate paste-able lines, so user sees branch state before staging anything. Hook is the backstop; AI rule is for not slipping in the first place.
+
+Refs: ADR-003, [docs/handoffs/2026-05-06-pr-h-precommit-hook.md](docs/handoffs/2026-05-06-pr-h-precommit-hook.md).
+
+---
+
 ## 2026-05-06 — PR-C: Xvfb stderr noise suppression
 
 First of three split PRs replacing the original PR-B omnibus per ADR-003. Smallest of the trio — ships first to clear the plate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ For more elaborate per-user preferences (editor tabs, indent style, naming conve
 | Docker container `db/` is **separate** from host `~/Nalana-eval/db/`. When analyzing retry stats etc., gather from BOTH | mount config in `docker-compose.yml` |
 | Some pre-`98ce599` runs may have stale schema columns; reading old reports may need null-safe access | — |
 | `.claude/` and `.env` are local secrets, gitignored. `AGENTS.md` and `CLAUDE.md` are **version controlled** — they are documentation, not config. | `.gitignore` |
+| Direct commits to `main` / `master` are blocked by a `pre-commit` hook. Run `bash scripts/setup-git-hooks.sh` once after cloning to install. Bypass with `git commit --no-verify`. | `scripts/git-hooks/pre-commit` |
 
 ---
 
@@ -158,6 +159,21 @@ Hard rule for the user: **after any merge happens via GitHub UI, run `git fetch 
 
 For codebase verification, prefer `Read` / `Grep` against the working-tree files directly — those don't touch `.git/`. Reserve sandbox bash git for read-only operations against branches/refs you can prove safe (e.g. `git log` without index work), and **never** while the user is mid-flight on a `git commit` / `git rebase` / merge.
 
+### AI commit recipe always verifies branch first
+
+Cautionary case (2026-05-06): three commits in one session landed on the wrong branch (twice on `main`, once on a stale topic branch) because branch verification was implicit, not enforced. Each one cost a recover-via-cherry-pick + reset round-trip.
+
+Hard rule for the AI: **any command sequence that includes `git add` or `git commit` MUST start with the following two verification commands as separate, paste-able lines:**
+
+```bash
+git branch --show-current        # what branch am I on?
+git status -sb                   # what's modified, what's clean?
+```
+
+Only after the user can see those two outputs and confirm the branch matches the intended PR target should the recipe continue with `git checkout -b` (if branching is needed) or `git add` (if branch is correct). Don't bury verification inside a multi-line block — the user's terminal paste pipeline can lose lines or mis-interpret comments. Each verification step should be its own paste-able command.
+
+The `pre-commit` hook (see Repo-specific gotchas) refuses commits on `main` / `master` as a backstop. Don't rely on the hook alone — verify branch FIRST. The hook is for catching slips; the AI rule is for not slipping.
+
 ### "Behind main" alone is not a delete signal
 
 Long-lived working branches (e.g. `ian_workspace`) live behind `main` by design — they accumulate work, then merge forward when ready. The user's workflow may forbid pushing to `main` directly, in which case branches like this are critical, not dead. Cautionary case (2026-05-06): the AI mass-listed `ian_workspace` for deletion alongside actually-orphaned topic branches based on a stale `[behind 2]` indicator; the user caught it before any damage but the local copy was already gone and had to be re-checked-out from `origin`.
@@ -185,6 +201,7 @@ Planned but not yet implemented. Use the markdown templates manually:
 
 ## Last updated
 
+> 2026-05-06 by ian + Claude (added "AI commit recipe always verifies branch first" rule + pre-commit hook gotcha row; companion to scripts/git-hooks/pre-commit).
 > 2026-05-06 by ian + Claude (added "Sandbox shell and .git/" + "behind main is not a delete signal" rules).
 > 2026-05-06 by ian + Claude (added "Sync before reasoning about git state" rule + cautionary case).
 > 2026-05-06 by ian + Claude (added "Issue / task numbering convention" section).

--- a/docs/handoffs/2026-05-06-pr-h-precommit-hook.md
+++ b/docs/handoffs/2026-05-06-pr-h-precommit-hook.md
@@ -1,0 +1,104 @@
+# Handoff: PR-H — pre-commit hook + AI commit recipe rule
+
+```yaml
+status:        in_progress
+owner:         ian + Claude Cowork
+related_task:  internal #31 (no GitHub issue — cleanup-track PR per CLAUDE.md numbering convention)
+related_pr:    (TBD on push)
+date_opened:   2026-05-06
+date_closed:   —
+```
+
+---
+
+## 1. What this is
+
+Tier 1 preventive tooling for the "commit landed on wrong branch" class of mistakes that hit three times in a single session today (twice on `main`, once on a stale topic branch), each costing a cherry-pick + reset round-trip. Adds a `pre-commit` hook that blocks direct commits on `main` / `master`, plus an AI-side rule in CLAUDE.md that mandates branch verification as the first step of any commit recipe. The hook is the backstop; the rule is for not slipping in the first place.
+
+## 2. Why now — what triggered this
+
+Three concrete events in today's session, all share the same root cause (`git checkout -b` was either forgotten or lost during paste):
+
+1. **PR-G commit landed on `main`** — recovery: `git checkout -b` from current HEAD then `git reset --hard origin/main` on main. ~15 min wasted.
+2. **PR-G push pushed empty branch** — discovered when GitHub compare showed "no changes". Recovery: same shape. ~15 min wasted.
+3. **#15.2 commit landed on stale `ian/pr-g-sandbox-and-branch-rules`** — recovery: same shape. ~10 min wasted.
+
+The post-incident discussion concluded these would all have been impossible (or instantly diagnosed) if (a) `git commit` on `main` were blocked by a hook, and (b) every AI-supplied commit recipe started with explicit branch verification.
+
+## 3. Scope
+
+```
+In:
+- scripts/git-hooks/pre-commit             — the hook script
+- scripts/setup-git-hooks.sh               — idempotent installer for per-clone setup
+- CLAUDE.md                                — new gotcha row + new "AI commit recipe
+                                              always verifies branch first" sub-rule
+- CHANGELOG.md                             — entry block
+- docs/handoffs/2026-05-06-pr-h-precommit-hook.md  — this file
+
+Out (deferred):
+- Tier 3 ergonomics (gnb shell alias, git switch promotion)        — per-user config,
+                                                                     not repo concern
+- Pre-push hooks                                                    — paranoia tier;
+                                                                     not warranted by
+                                                                     today's incidents
+- Branch protection rules on GitHub                                 — already in place;
+                                                                     ian can't push to main
+                                                                     directly (this PR
+                                                                     handles the LOCAL
+                                                                     gap, where `git
+                                                                     commit` to main
+                                                                     was the actual
+                                                                     point of failure)
+```
+
+## 4. Decisions made
+
+```
+Q: Hook bypass mechanism — none, env var, or --no-verify?
+→ --no-verify (git's standard). Preserves a single, well-known escape hatch.
+  Custom env vars or interactive prompts add cognitive load.
+
+Q: Block which branches?
+→ main + master only. ian_workspace and other long-lived branches are
+  legitimate commit targets per ian's workflow. Hardcoding the deny-list
+  beats parameterizing it; the set is small and stable.
+
+Q: Hook source location — track in repo or live only in .git/hooks/?
+→ Track in scripts/git-hooks/, install via scripts/setup-git-hooks.sh.
+  .git/hooks/ isn't git-tracked, so without a tracked source other
+  contributors (Brian) won't get the hook on their clones. Tracked
+  source + per-clone install script is the standard pattern.
+
+Q: AI rule — bury in existing "Sync before reasoning" section, or new section?
+→ Sub-rule inside the existing section. The "verify branch before commit"
+  rule is conceptually the same family as "verify state before reasoning"
+  — both about preventing decisions on stale/wrong assumptions. Keeping
+  related rules together makes them easier to recall as a coherent set.
+```
+
+## 5. How to verify
+
+- [ ] `bash scripts/setup-git-hooks.sh` from repo root prints `Installed: pre-commit` and exits 0
+- [ ] `ls -la .git/hooks/pre-commit` shows the file is executable (`-rwxr-xr-x` or similar)
+- [ ] On `main` branch with a dummy change: `git add foo && git commit -m test` → hook prints the error message and exits non-zero; no commit created (`git log` HEAD unchanged)
+- [ ] On `main` with `--no-verify`: `git commit --no-verify -m test` → succeeds (then `git reset --hard HEAD~1` to undo the test)
+- [ ] On a topic branch: `git commit -m test` → hook does not interfere
+- [ ] CLAUDE.md gotcha table has the new "Direct commits to main / master are blocked" row
+- [ ] CLAUDE.md "Sync before reasoning about git state" section now has a fourth sub-rule "AI commit recipe always verifies branch first"
+
+## 6. Known issues / TODOs / handoff to next
+
+- **Brian (and any future contributor) needs to run `bash scripts/setup-git-hooks.sh` once** after clone to get the hook. Worth a note when this PR merges. README could mention it under "First-time setup" if/when that section gets written; for now the gotcha row in CLAUDE.md and the install script's name are self-explanatory.
+- **The AI rule is a self-imposed discipline, not enforceable** — no tool can verify the AI inserted `git branch --show-current` as the first line. Effectiveness depends on the AI re-reading CLAUDE.md per session-start workflow. The hook covers the user-side slip; the rule covers the AI-side slip. Both are needed.
+- **`scripts/` directory is new in this PR** — repo previously had no `scripts/` folder. If a Python `scripts/` convention emerges later, the shell scripts here are still appropriate (shell hooks must be shell, not Python).
+- **No pre-push hook**. We discussed but rejected — today's incidents were all `commit`-time, not `push`-time. Add later if pre-push slip ever happens.
+
+## 7. References
+
+- ADR-003 (one PR = one concern) — this PR's single concern is "preventive tooling for today's git mishaps"
+- CLAUDE.md sections "Sync before reasoning about git state" / "Sandbox shell and the user's `.git/` don't mix" / "'Behind main' alone is not a delete signal" — the existing companion rules from earlier in today's session
+- Today's three commit-mishap incidents:
+  - PR-G commit on `main` (recovered via cherry-pick + reset)
+  - PR-G empty push (recovered via re-commit on correct branch)
+  - #15.2 commit on stale `ian/pr-g-sandbox-and-branch-rules` (recovered via cherry-pick onto fresh branch from main)

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Refuse direct commits on main / master.
+#
+# All work goes through topic branches + PRs per ADR-003. This hook
+# prevents the "I forgot git checkout -b" class of accidents that
+# repeatedly cost cleanup time on 2026-05-06 (three commits landed on
+# the wrong branch in a single session).
+#
+# Installed by scripts/setup-git-hooks.sh. Hooks are not git-tracked,
+# so this needs to be run once per clone.
+#
+# Emergency bypass: git commit --no-verify
+
+set -e
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    echo "" >&2
+    echo "ERROR: Direct commits to '$branch' are blocked by repo policy (ADR-003)." >&2
+    echo "" >&2
+    echo "All work goes through a topic branch + PR. To proceed:" >&2
+    echo "  git stash             # save uncommitted changes" >&2
+    echo "  git checkout -b <topic-branch>   # e.g. ian/15.3-llm-authoring" >&2
+    echo "  git stash pop" >&2
+    echo "  git commit            # try again" >&2
+    echo "" >&2
+    echo "Emergency bypass (use sparingly): git commit --no-verify" >&2
+    echo "" >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install repo-local git hooks into .git/hooks/.
+#
+# Run once after cloning the repo. Hooks are not git-tracked
+# (.git/hooks/ lives outside the working tree), so each clone needs
+# its own install.
+#
+# What you get:
+#   - pre-commit: refuses direct commits on main / master
+#                 (use `git commit --no-verify` to bypass in emergencies)
+#
+# Idempotent: re-running overwrites with the latest hook source.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/scripts/git-hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$HOOKS_DST" ]; then
+    echo "ERROR: $HOOKS_DST not found. Are you inside a git repo?" >&2
+    exit 1
+fi
+
+if [ ! -d "$HOOKS_SRC" ]; then
+    echo "ERROR: $HOOKS_SRC not found. Repo layout unexpected." >&2
+    exit 1
+fi
+
+installed=0
+for hook in "$HOOKS_SRC"/*; do
+    [ -f "$hook" ] || continue
+    name="$(basename "$hook")"
+    cp "$hook" "$HOOKS_DST/$name"
+    chmod +x "$HOOKS_DST/$name"
+    echo "  Installed: $name"
+    installed=$((installed + 1))
+done
+
+if [ "$installed" -eq 0 ]; then
+    echo "ERROR: no hook files found under $HOOKS_SRC" >&2
+    exit 1
+fi
+
+echo ""
+echo "Installed $installed hook(s) into $HOOKS_DST/"
+echo "Bypass any hook with: git commit --no-verify"


### PR DESCRIPTION
Tier 1 preventive tooling for the 'commit landed on wrong branch' class of mistakes that hit three times in a single session today (twice on main, once on a stale topic branch), each costing a cherry-pick + reset round-trip.

New tooling:
- scripts/git-hooks/pre-commit: refuses commits on main/master with a help message pointing to git checkout -b. Bypass with --no-verify.
- scripts/setup-git-hooks.sh: idempotent installer; copies repo-tracked hooks into .git/hooks/. Per-clone setup since hooks aren't git-tracked. Brian + future contributors should run this once.

CLAUDE.md updates:
- New gotcha row pointing to the hook setup.
- New sub-rule under 'Sync before reasoning about git state': AI commit recipe always verifies branch first — every command sequence containing 'git add' / 'git commit' MUST start with 'git branch --show-current' and 'git status -sb' as separate paste-able lines. Hook is the backstop; AI rule is for not slipping in the first place.

Refs: ADR-003, docs/handoffs/2026-05-06-pr-h-precommit-hook.md.